### PR TITLE
Feature/#9 chatroom

### DIFF
--- a/infra/dev/app/Dockerfile
+++ b/infra/dev/app/Dockerfile
@@ -19,6 +19,3 @@ COPY ./src .
 
 # 依存関係のチェックを含むビルドステップを追加
 RUN go build -o /dev/null ./...
-
-# コンテナ起動時にmain.goを実行
-CMD ["go", "run", "main.go"]

--- a/src/main.go
+++ b/src/main.go
@@ -16,6 +16,6 @@ func main() {
 		log.Print("Error loading .env file")
 	}
 
-	http.HandleFunc("/chat", auth.Authenticate(websocket.Echo))
+	http.HandleFunc("/chat", auth.Authenticate(websocket.HandleChat))
 	http.ListenAndServe(os.Getenv("PORT"), nil)
 }

--- a/src/pkg/auth/middleware.go
+++ b/src/pkg/auth/middleware.go
@@ -1,12 +1,17 @@
+// middleware.go
+
 package auth
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
 
 	"github.com/golang-jwt/jwt/v5"
 )
+
+type ClaimsKey struct{}
 
 func Authenticate(next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -33,6 +38,10 @@ func Authenticate(next http.HandlerFunc) http.HandlerFunc {
 			fmt.Printf("type: %v\n", claims["type"])
 			fmt.Printf("exp: %v\n", int64(claims["exp"].(float64)))
 		}
+
+		// クレームをコンテキストに格納
+		ctx := context.WithValue(r.Context(), ClaimsKey{}, token.Claims)
+		r = r.WithContext(ctx)
 
 		next.ServeHTTP(w, r)
 	})

--- a/src/pkg/websocket/chatroom.go
+++ b/src/pkg/websocket/chatroom.go
@@ -64,12 +64,6 @@ func RemoveClient(client *Client, connectionType string) {
 			chatRoom.admin = nil
 			log.Printf("Admin %d disconnected from chat room for customer %d", client.adminID, client.customerID)
 		}
-
-		// 両方のクライアントが切断された場合、チャットルームを削除
-		if chatRoom.customer == nil && chatRoom.admin == nil {
-			delete(chatRooms, client.customerID)
-			log.Printf("Chat room for customer %d deleted", client.customerID)
-		}
 	}
 }
 

--- a/src/pkg/websocket/chatroom.go
+++ b/src/pkg/websocket/chatroom.go
@@ -1,0 +1,96 @@
+package websocket
+
+import (
+	"log"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+type Client struct {
+	conn       *websocket.Conn
+	customerID int64
+	adminID    int64
+}
+
+type ChatRoom struct {
+	customer *Client
+	admin    *Client
+}
+
+// チャットルームを保持するハッシュテーブル
+var chatRooms = make(map[int64]*ChatRoom)
+var mu sync.Mutex // Protects chatRooms
+
+// チャットルームにクライアントを追加する
+func AddClient(client *Client, connectionType string) bool {
+	mu.Lock()
+	defer mu.Unlock()
+
+	chatRoom, exists := chatRooms[client.customerID]
+	if !exists && connectionType == "create" {
+		chatRoom = &ChatRoom{customer: client}
+		chatRooms[client.customerID] = chatRoom
+		log.Printf("Created chat room for customer %d", client.customerID)
+		return true
+	} else if exists && connectionType == "join" {
+		if chatRoom.admin == nil && client.adminID != 0 {
+			chatRoom.admin = client
+			log.Printf("Admin %d joined chat room for customer %d", client.adminID, client.customerID)
+			return true
+		}
+		log.Printf("Admin %d is already connected to chat room for customer %d or invalid adminID", client.adminID, client.customerID)
+		return false
+	}
+	return false
+}
+
+// チャットルームからクライアントを削除する
+func RemoveClient(client *Client, connectionType string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	chatRoom, exists := chatRooms[client.customerID]
+	if !exists {
+		return
+	}
+
+	if connectionType == "create" {
+		delete(chatRooms, client.customerID)
+		log.Printf("Deleted chat room for customer %d", client.customerID)
+	} else if connectionType == "join" {
+		chatRoom.admin = nil
+		if chatRoom.customer == nil {
+			delete(chatRooms, client.customerID)
+			log.Printf("Deleted chat room for customer %d", client.customerID)
+		}
+	}
+}
+
+// チャットルーム内の他のクライアントにメッセージを中継する
+func RelayMessage(client *Client, messageType int, message []byte) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	chatRoom, exists := chatRooms[client.customerID]
+	if !exists {
+		return
+	}
+
+	var targetConn *websocket.Conn
+	if client.adminID == 0 && chatRoom.admin != nil { // Customer sending message to admin
+		targetConn = chatRoom.admin.conn
+	} else if client.adminID != 0 && chatRoom.customer != nil { // Admin sending message to customer
+		targetConn = chatRoom.customer.conn
+	}
+
+	if targetConn != nil {
+		err := targetConn.WriteMessage(messageType, message)
+		if err != nil {
+			log.Printf("write error: %v", err)
+		}
+		log.Printf("send: %s", message)
+	} else {
+		log.Println("No target connection available")
+	}
+}

--- a/src/pkg/websocket/handler.go
+++ b/src/pkg/websocket/handler.go
@@ -3,28 +3,56 @@ package websocket
 import (
 	"log"
 	"net/http"
+
+	"github.com/gorilla/websocket"
+	"github.com/golang-jwt/jwt/v5"
+	"E-Commerce-Chat-Microservice/pkg/auth"
 )
 
-func Echo(w http.ResponseWriter, r *http.Request) {
+func HandleChat(w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Print("upgrade:", err)
 		return
 	}
 	defer conn.Close()
+
+	// コンテキストからクレームを取得
+	claims, ok := r.Context().Value(auth.ClaimsKey{}).(jwt.MapClaims)
+	if !ok {
+		log.Println("Failed to get claims from context")
+		return
+	}
+
+	customerID := int64(claims["customer_id"].(float64))
+	adminID := int64(0)
+	if claims["admin_id"] != nil {
+		adminID = int64(claims["admin_id"].(float64))
+	}
+	connectionType := claims["type"].(string)
+
+	log.Printf("customerID: %d, adminID: %d, connectionType: %s", customerID, adminID, connectionType)
+
+	client := &Client{conn: conn, customerID: customerID, adminID: adminID}
+
+	added := AddClient(client, connectionType)
+	if !added {
+		log.Printf("Failed to add client to chat room: customerID=%d, adminID=%d, connectionType=%s", customerID, adminID, connectionType)
+		return
+	}
+
+	defer RemoveClient(client, connectionType)
+
 	for {
 		messageType, message, err := conn.ReadMessage()
 		if err != nil {
-			log.Println("read:", err)
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				log.Printf("read error: %v", err)
+			}
 			break
 		}
 		log.Printf("recv: %s", message)
-		err = conn.WriteMessage(messageType, message)
-		if err != nil {
-			log.Println("write:", err)
-			break
-		} else {
-			log.Printf("send: %s", message)
-		}
+
+		RelayMessage(client, messageType, message)
 	}
 }


### PR DESCRIPTION
## 概要

- チャットルーム作成
- チャットルーム内のメンバーにメッセージを中継

### Issue
#9 

## 目的
バックエンドに送信されたメッセージを適切なクライアントに中継する

## やったこと
- チャットルームパッケージ作成
- チャットルームを扱うための構造体作成
- 中継処理の作成
- 再接続の処理

## やってないこと
- メッセージの中継以外のことは行ってません。
- 画像の送信


## チャットルームの構造
```
chatRooms (ハッシュテーブル)
+---------------------------------+
| customerID (int64) -> ChatRoom  |
+---------------------------------+

ChatRoom (構造体)
+-----------------------------------------+
| customer: *Client                       |
| admin:    *Client                       |
+-----------------------------------------+

Client (構造体)
+-----------------------------------------+
| conn:       *websocket.Conn             |
| customerID: int64                       |
| adminID:    int64                       |
+-----------------------------------------+

```

## 事前準備
[こちらのPRと連動してます](https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/compare/%2379_display_message?expand=1)
1. Rails側のPRの反映を行うと確認しやすいです(なくても動きます)
2. adminアカウントの作成
3. customerアカウントの作成

## 確認方法
**顧客側**
1. メニュー > チャット画面に入る
2. そのまま待機


**管理者側**
1. メニュー > チャットリスト > 顧客側で作成してるチャットに接続する
2. ここからクライアントとチャットができるか確認



https://github.com/recursion-backend-projects/E-Commerce-Chat-Microservice/assets/69625901/9ba4f139-8bc0-400d-a869-c1af4e90fecd





## レビューで見てほしいこと、不安に思っていること

- メッセージのやり取りが問題なくできるか