### PR TITLE
websocketの解除処理

### DIFF
--- a/compose.stg.yml
+++ b/compose.stg.yml
@@ -19,6 +19,7 @@ services:
     environment:
       DOMAINS: "chat.art-sa2-stg.com -> http://go_server:8080"
       STAGE: "production"
+      WEBSOCKET: "true"
     volumes:
       - https-portal-data:/var/lib/https-portal
 

--- a/compose.stg.yml
+++ b/compose.stg.yml
@@ -1,5 +1,5 @@
 services:
-  go-server:
+  go_server:
     build:
       context: .
       dockerfile: infra/dev/app/Dockerfile

--- a/src/pkg/websocket/chatroom.go
+++ b/src/pkg/websocket/chatroom.go
@@ -59,9 +59,11 @@ func RemoveClient(client *Client, connectionType string) {
 	if exists {
 		if connectionType == "create" {
 			chatRoom.customer = nil
+			chatRoom.admin.conn.Close()
 			log.Printf("Customer %d disconnected", client.customerID)
 		} else if connectionType == "join" {
 			chatRoom.admin = nil
+			chatRoom.customer.conn.Close()
 			log.Printf("Admin %d disconnected from chat room for customer %d", client.adminID, client.customerID)
 		}
 	}


### PR DESCRIPTION
## 概要

このPRで使います。
https://github.com/recursion-backend-projects/E-Commerce-Webapp-with-Stripe-Sync/pull/122

### Issue

## 目的
片方のクライアントが接続を解除した場合、もう片方のクライアントの接続も解除する

## やったこと
- websocketの接続を解除する処理を追加
- websocketの利用許可設定

## 確認方法
コンテナ起動後
go_serverコンテナに入り以下を実行
```
go run main.go
```

本番環境は無料枠を超えないようにチャットサーバーは定期的に停止させてます。
もし起動してない場合は声をかけてください。


## レビューで見てほしいこと、不安に思っていること
問題なくgoサーバーが起動してるかどうか


